### PR TITLE
Use scheme-relative links to NetBSD.org, pkgsrc.org, pkgsrc.se.

### DIFF
--- a/templates/pkg_info.html
+++ b/templates/pkg_info.html
@@ -4,7 +4,7 @@
         {{if eq .Category "joyent/"}}
         {{.Category}}{{.Dir}}
         {{else}}
-        <a href="http://pkgsrc.se/{{.Category}}{{.Dir}}">{{.Category}}{{.Dir}}</a></dd>
+        <a href="//pkgsrc.se/{{.Category}}{{.Dir}}">{{.Category}}{{.Dir}}</a></dd>
         {{end}}
       </dd>
       <dt>Package name</dt>

--- a/templates/start_page_lead.html
+++ b/templates/start_page_lead.html
@@ -1,9 +1,9 @@
   <div class="jumbotron">
     <p>BulkTracker is a web app to follow bulk build status in pkgsrc,
-      the <a href="http://www.NetBSD.org/">NetBSD</a> package collection.
+      the <a href="//www.NetBSD.org/">NetBSD</a> package collection.
     </p>
     <p>
-      <a class="btn btn-primary btn-lg" role="button" href="http://www.pkgsrc.org/">Learn more about pkgsrc</a>
+      <a class="btn btn-primary btn-lg" role="button" href="//www.pkgsrc.org/">Learn more about pkgsrc</a>
     </p>
   </div>
 


### PR DESCRIPTION
This way https clients don't get directed to http sites (but http-only clients also work).

fix https://github.com/bsiegert/BulkTracker/issues/58