### PR TITLE
Correct counting of indirect-failed packages

### DIFF
--- a/bulk/bulk.go
+++ b/bulk/bulk.go
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2014-2018, 2022-2023
+ * Copyright (c) 2014-2018, 2022-2024
  *      Benny Siegert <bsiegert@gmail.com>
  *
  * Provided that these terms and disclaimer and all copyright notices
@@ -126,8 +126,6 @@ func BuildFromReport(from string, r io.Reader) (*ddao.Build, error) {
 
 func PkgsFromReport(r io.Reader) ([]ddao.PkgResult, error) {
 	var pkgs []ddao.PkgResult
-	// Failed packages. The key is the name, the value an index into pkgs.
-	var failedPkgs = make(map[string]int)
 	var p *ddao.PkgResult
 	n := 0
 
@@ -150,15 +148,25 @@ func PkgsFromReport(r io.Reader) ([]ddao.PkgResult, error) {
 			p.Category, p.Dir = path.Split(string(val))
 		case bytes.Equal(key, []byte("BUILD_STATUS")):
 			p.BuildStatus = statuses[string(val)]
-			if p.BuildStatus != OK {
-				failedPkgs[p.PkgName] = n - 1
-			}
 		case bytes.Equal(key, []byte("DEPENDS")):
 			p.FailedDeps = string(val)
 		}
 	}
-	// Do another run over all indirect-failed packages, only keep
-	// dependencies that actually failed.
+
+	fixUpDependencies(pkgs)
+
+	return pkgs, s.Err()
+}
+
+// fixUpDependencies does another run over all indirect-failed packages and only keeps
+// dependencies that actually failed.
+func fixUpDependencies(pkg []ddao.PkgResult) {
+	// indices maps package name to its index in pkgs.
+	indices := make(map[string]int)
+	for i := range pkgs {
+		indices[pkgs[i].PkgName] = i
+	}
+
 	for i := range pkgs {
 		if pkgs[i].BuildStatus != IndirectFailed && pkgs[i].BuildStatus != IndirectPrefailed {
 			pkgs[i].FailedDeps = ""
@@ -166,11 +174,12 @@ func PkgsFromReport(r io.Reader) ([]ddao.PkgResult, error) {
 		failedDeps := strings.Fields(pkgs[i].FailedDeps)
 		f := make([]string, 0, len(failedDeps))
 		for _, dep := range failedDeps {
-			if fp, ok := failedPkgs[dep]; ok {
+			d := indices[dep]
+			if pkgs[d].BuildStatus != OK {
 				f = append(f, dep)
 				// TODO: if pkgs[fp] is indirect-failed, add to the counter of
 				// _its_ failed dependencies.
-				pkgs[fp].Breaks++
+				pkgs[d].Breaks++
 			}
 		}
 		if len(f) == 0 {
@@ -178,5 +187,4 @@ func PkgsFromReport(r io.Reader) ([]ddao.PkgResult, error) {
 		}
 		pkgs[i].FailedDeps = strings.Join(f, " ")
 	}
-	return pkgs, s.Err()
 }

--- a/bulk/bulk.go
+++ b/bulk/bulk.go
@@ -160,7 +160,7 @@ func PkgsFromReport(r io.Reader) ([]ddao.PkgResult, error) {
 
 // fixUpDependencies does another run over all indirect-failed packages and only keeps
 // dependencies that actually failed.
-func fixUpDependencies(pkg []ddao.PkgResult) {
+func fixUpDependencies(pkgs []ddao.PkgResult) {
 	// indices maps package name to its index in pkgs.
 	indices := make(map[string]int)
 	for i := range pkgs {
@@ -170,12 +170,13 @@ func fixUpDependencies(pkg []ddao.PkgResult) {
 	for i := range pkgs {
 		if pkgs[i].BuildStatus != IndirectFailed && pkgs[i].BuildStatus != IndirectPrefailed {
 			pkgs[i].FailedDeps = ""
+			continue
+
 		}
 		failedDeps := strings.Fields(pkgs[i].FailedDeps)
 		f := make([]string, 0, len(failedDeps))
 		for _, dep := range failedDeps {
-			d := indices[dep]
-			if pkgs[d].BuildStatus != OK {
+			if d, ok := indices[dep]; ok && pkgs[d].BuildStatus != OK {
 				f = append(f, dep)
 				// TODO: if pkgs[fp] is indirect-failed, add to the counter of
 				// _its_ failed dependencies.

--- a/bulk/bulk.go
+++ b/bulk/bulk.go
@@ -124,7 +124,7 @@ func BuildFromReport(from string, r io.Reader) (*ddao.Build, error) {
 	return b, s.Err()
 }
 
-func PkgsFromReport(r io.Reader) ([]ddao.PkgResult, error) {
+func ResultsFromReport(r io.Reader) ([]ddao.PkgResult, error) {
 	var pkgs []ddao.PkgResult
 	var p *ddao.PkgResult
 	n := 0
@@ -153,14 +153,12 @@ func PkgsFromReport(r io.Reader) ([]ddao.PkgResult, error) {
 		}
 	}
 
-	fixUpDependencies(pkgs)
-
 	return pkgs, s.Err()
 }
 
-// fixUpDependencies does another run over all indirect-failed packages and only keeps
+// FixUpDependencies does another run over all indirect-failed packages and only keeps
 // dependencies that actually failed.
-func fixUpDependencies(pkgs []ddao.PkgResult) {
+func FixUpDependencies(pkgs []ddao.PkgResult) {
 	// indices maps package name to its index in pkgs.
 	indices := make(map[string]int)
 	for i := range pkgs {

--- a/bulk/bulk.go
+++ b/bulk/bulk.go
@@ -28,6 +28,7 @@ import (
 	"errors"
 	"io"
 	"path"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -172,18 +173,39 @@ func FixUpDependencies(pkgs []ddao.PkgResult) {
 
 		}
 		failedDeps := strings.Fields(pkgs[i].FailedDeps)
-		f := make([]string, 0, len(failedDeps))
-		for _, dep := range failedDeps {
-			if d, ok := indices[dep]; ok && pkgs[d].BuildStatus != OK {
-				f = append(f, dep)
-				// TODO: if pkgs[fp] is indirect-failed, add to the counter of
-				// _its_ failed dependencies.
-				pkgs[d].Breaks++
+
+		// For all indirect-failed dependencies, add *their*
+		// dependencies too. Try avoiding duplicates.
+		//
+		// This form of iteration that tolerates stuff being added
+		// mid-iteration.
+		for j := 0; j < len(failedDeps); j++ {
+			d, ok := indices[failedDeps[j]]
+			if !ok {
+				// TODO: consider removing the entry instead.
+				continue
+			}
+			switch pkgs[d].BuildStatus {
+			case IndirectFailed, IndirectPrefailed:
+				for _, indirectDep := range strings.Fields(pkgs[d].FailedDeps) {
+					if !slices.Contains(failedDeps, indirectDep) {
+						failedDeps = append(failedDeps, indirectDep)
+					}
+				}
 			}
 		}
-		if len(f) == 0 {
-			f = nil
+
+		// Step 2: prune failed dependencies, keep only Failed and Prefailed.
+		newDeps := make([]string, 0, len(failedDeps))
+		for _, dep := range failedDeps {
+			if d, ok := indices[dep]; ok {
+				switch pkgs[d].BuildStatus {
+				case Failed, Prefailed:
+					newDeps = append(newDeps, dep)
+					pkgs[d].Breaks++
+				}
+			}
 		}
-		pkgs[i].FailedDeps = strings.Join(f, " ")
+		pkgs[i].FailedDeps = strings.Join(newDeps, " ")
 	}
 }

--- a/bulk/bulk_test.go
+++ b/bulk/bulk_test.go
@@ -116,16 +116,15 @@ func TestFixUpDependencies(t *testing.T) {
 				{
 					PkgName:     "a",
 					BuildStatus: IndirectFailed,
-					FailedDeps:  "b",
+					FailedDeps:  "c",
 				}, {
 					PkgName:     "b",
 					BuildStatus: IndirectFailed,
 					FailedDeps:  "c",
-					Breaks:      1,
 				}, {
 					PkgName:     "c",
 					BuildStatus: Failed,
-					Breaks:      1, // 2?
+					Breaks:      2,
 				},
 			},
 		}, {
@@ -149,12 +148,11 @@ func TestFixUpDependencies(t *testing.T) {
 				{
 					PkgName:     "a",
 					BuildStatus: IndirectFailed,
-					FailedDeps:  "b c",
+					FailedDeps:  "c",
 				}, {
 					PkgName:     "b",
 					BuildStatus: IndirectFailed,
 					FailedDeps:  "c",
-					Breaks:      1,
 				}, {
 					PkgName:     "c",
 					BuildStatus: Failed,

--- a/bulk/bulk_test.go
+++ b/bulk/bulk_test.go
@@ -46,7 +46,7 @@ BUILD_STATUS=indirect-failed
 DEPENDS=foo-1.0
 `
 
-func TestPkgsFromReport(t *testing.T) {
+func TestResultsFromReport(t *testing.T) {
 	var tests = []struct {
 		name   string
 		report string
@@ -112,7 +112,8 @@ func TestPkgsFromReport(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, _ := PkgsFromReport(strings.NewReader(test.report))
+			got, _ := ResultsFromReport(strings.NewReader(test.report))
+			FixUpDependencies(got)
 			if diff := cmp.Diff(got, test.want); diff != "" {
 				t.Errorf("PkgsFromReport(): unexpected diff (+got -want)\n%s", diff)
 			}

--- a/bulk/bulk_test.go
+++ b/bulk/bulk_test.go
@@ -46,65 +46,119 @@ BUILD_STATUS=indirect-failed
 DEPENDS=foo-1.0
 `
 
-func TestResultsFromReport(t *testing.T) {
+func toPkgResult(r []ddao.Result) []ddao.PkgResult {
+	ret := make([]ddao.PkgResult, len(r))
+	for i := range r {
+		ret[i].Result = r[i]
+	}
+	return ret
+}
+
+func TestFixUpDependencies(t *testing.T) {
 	var tests = []struct {
-		name   string
-		report string
-		want   []ddao.PkgResult
+		name string
+		in   []ddao.Result
+		want []ddao.Result
 	}{
 		{
-			"single package",
-			pkgFoo,
-			[]ddao.PkgResult{{
-				Result: ddao.Result{
-					PkgName:     "foo-1.0",
-					BuildStatus: IndirectFailed,
-				},
+			name: "no change",
+			in: []ddao.Result{{
+				PkgName:     "a",
+				BuildStatus: Failed,
 			}},
-		},
-		{
-			"indirect failed",
-			pkgFoo + pkgBar,
-			[]ddao.PkgResult{
+			want: []ddao.Result{{
+				PkgName:     "a",
+				BuildStatus: Failed,
+			},
+			},
+		}, {
+			name: "indirect failed",
+			in: []ddao.Result{
 				{
-					Result: ddao.Result{
-						PkgName:     "foo-1.0",
-						BuildStatus: IndirectFailed,
-						FailedDeps:  "bar-2.0",
-					},
+					PkgName:     "a",
+					BuildStatus: IndirectFailed,
+					FailedDeps:  "b",
 				}, {
-					Result: ddao.Result{
-						PkgName:     "bar-2.0",
-						BuildStatus: Failed,
-						Breaks:      1,
-					},
+					PkgName:     "b",
+					BuildStatus: Failed,
+					FailedDeps:  "some other stuff",
 				},
 			},
-		},
-		{
-			"depending on indirect failed",
-			pkgDoubleIndirect + pkgFoo + pkgBar,
-			[]ddao.PkgResult{
+			want: []ddao.Result{
 				{
-					Result: ddao.Result{
-						PkgName:     "double-3.0",
-						BuildStatus: IndirectFailed,
-						FailedDeps:  "foo-1.0",
-					},
+					PkgName:     "a",
+					BuildStatus: IndirectFailed,
+					FailedDeps:  "b",
 				}, {
-					Result: ddao.Result{
-						PkgName:     "foo-1.0",
-						BuildStatus: IndirectFailed,
-						FailedDeps:  "bar-2.0",
-						Breaks:      1,
-					},
+					PkgName:     "b",
+					BuildStatus: Failed,
+					Breaks:      1,
+				},
+			},
+		}, {
+			name: "depending on indirect failed",
+			in: []ddao.Result{
+				{
+					PkgName:     "a",
+					BuildStatus: IndirectFailed,
+					FailedDeps:  "b",
 				}, {
-					Result: ddao.Result{
-						PkgName:     "bar-2.0",
-						BuildStatus: Failed,
-						// TODO: arguably, this should be 2, since it breaks the two other packages.
-						Breaks: 1,
-					},
+					PkgName:     "b",
+					BuildStatus: IndirectFailed,
+					FailedDeps:  "c",
+				}, {
+					PkgName:     "c",
+					BuildStatus: Failed,
+					FailedDeps:  "some other stuff",
+				},
+			},
+			want: []ddao.Result{
+				{
+					PkgName:     "a",
+					BuildStatus: IndirectFailed,
+					FailedDeps:  "b",
+				}, {
+					PkgName:     "b",
+					BuildStatus: IndirectFailed,
+					FailedDeps:  "c",
+					Breaks:      1,
+				}, {
+					PkgName:     "c",
+					BuildStatus: Failed,
+					Breaks:      1, // 2?
+				},
+			},
+		}, {
+			name: "double counting",
+			in: []ddao.Result{
+				{
+					PkgName:     "a",
+					BuildStatus: IndirectFailed,
+					FailedDeps:  "b c",
+				}, {
+					PkgName:     "b",
+					BuildStatus: IndirectFailed,
+					FailedDeps:  "c",
+				}, {
+					PkgName:     "c",
+					BuildStatus: Failed,
+					FailedDeps:  "some other stuff",
+				},
+			},
+			want: []ddao.Result{
+				{
+					PkgName:     "a",
+					BuildStatus: IndirectFailed,
+					FailedDeps:  "b c",
+				}, {
+					PkgName:     "b",
+					BuildStatus: IndirectFailed,
+					FailedDeps:  "c",
+					Breaks:      1,
+				}, {
+					PkgName:     "c",
+					BuildStatus: Failed,
+					Breaks:      2,
 				},
 			},
 		},
@@ -112,11 +166,41 @@ func TestResultsFromReport(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, _ := ResultsFromReport(strings.NewReader(test.report))
+			want := toPkgResult(test.want)
+			got := toPkgResult(test.in)
 			FixUpDependencies(got)
-			if diff := cmp.Diff(got, test.want); diff != "" {
-				t.Errorf("PkgsFromReport(): unexpected diff (+got -want)\n%s", diff)
+			if diff := cmp.Diff(got, want); diff != "" {
+				t.Errorf("FixUpDependencies(): unexpected diff (+got -want)\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestResultsFromReport(t *testing.T) {
+	report := pkgDoubleIndirect + pkgFoo + pkgBar
+	want := []ddao.PkgResult{
+		{
+			Result: ddao.Result{
+				PkgName:     "double-3.0",
+				BuildStatus: IndirectFailed,
+				FailedDeps:  "foo-1.0",
+			},
+		}, {
+			Result: ddao.Result{
+				PkgName:     "foo-1.0",
+				BuildStatus: IndirectFailed,
+				FailedDeps:  "bar-2.0",
+			},
+		}, {
+			Result: ddao.Result{
+				PkgName:     "bar-2.0",
+				BuildStatus: Failed,
+			},
+		},
+	}
+
+	got, _ := ResultsFromReport(strings.NewReader(report))
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("ResultsFromReport(): unexpected diff (+got -want)\n%s", diff)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bsiegert/BulkTracker
 
-go 1.18
+go 1.22
 
 require (
 	github.com/TV4/logrus-stackdriver-formatter v0.1.0

--- a/ingest/ingest.go
+++ b/ingest/ingest.go
@@ -193,7 +193,7 @@ func (i *IncomingMailHandler) FetchReport(ctx context.Context, buildID int64, ur
 		})
 		return
 	}
-	pkgs, err := bulk.PkgsFromReport(r)
+	results, err := bulk.ResultsFromReport(r)
 	if err != nil {
 		log.Errorf(ctx, "failed to parse report at %q: %s", url, err)
 		i.DB.SetBuildLastError(ctx, ddao.SetBuildLastErrorParams{
@@ -205,8 +205,9 @@ func (i *IncomingMailHandler) FetchReport(ctx context.Context, buildID int64, ur
 		})
 		return
 	}
+	bulk.FixUpDependencies(results)
 
-	if err = i.DB.PutResults(ctx, pkgs, buildID); err != nil {
+	if err = i.DB.PutResults(ctx, results, buildID); err != nil {
 		log.Warningf(ctx, "%s", err)
 	}
 }


### PR DESCRIPTION
Fixes #70.

This changes the algorithm to determine failed dependencies like `pbulk` does.

A package is now only considered to "break" another package if it is Failed or Prefailed, not IndirectFailed or IndirectPrefailed.

So if `a` depends on `b` depends on `c`, and `c` failed to build, `a`'s failed dependency is `c`, not `b`. There is a test for exactly this!

Tested locally. The test dataset looks very different now!

NB: Once deployed, this will only be used in newly published build reports. Older ones will continue using the old method.