### PR TITLE
Tweaked queries to allow for null values

### DIFF
--- a/ddao/queries.sql.go
+++ b/ddao/queries.sql.go
@@ -22,9 +22,11 @@ func (q *Queries) DeleteAllForBuild(ctx context.Context, buildID sql.NullInt64) 
 }
 
 const getAllPkgResults = `-- name: GetAllPkgResults :many
-SELECT r.result_id, r.pkg_name, m.pkg_maintainer, r.build_status, r.breaks, b.build_id, b.platform, b.build_ts, b.branch, b.compiler, b.build_user
-FROM results r, builds b, maintainers m
-WHERE r.build_id == b.build_id AND r.maintainer_id == m.maintainer_id AND r.pkg_id == ?
+SELECT r.result_id, r.pkg_name, COALESCE(m.pkg_maintainer, '') AS pkg_maintainer, r.build_status, r.breaks, b.build_id, b.platform, b.build_ts, b.branch, b.compiler, b.build_user
+FROM results r
+JOIN builds b ON (r.build_id == b.build_id)
+LEFT JOIN maintainers m ON (r.maintainer_id == m.maintainer_id)
+WHERE r.pkg_id == ?
 ORDER BY b.build_ts DESC
 `
 
@@ -217,12 +219,13 @@ SELECT
 	r.result_id,
 	(p.category || p.dir) AS pkg_path,
 	r.pkg_name,
-	m.pkg_maintainer,
+	COALESCE(m.pkg_maintainer, '') AS pkg_maintainer,
 	r.build_status,
 	r.failed_deps,
 	r.breaks
-FROM results r, maintainers m
-JOIN pkgs p ON (r.pkg_id == p.pkg_id) AND r.maintainer_id == m.maintainer_id
+FROM results r
+LEFT JOIN maintainers m ON (r.maintainer_id == m.maintainer_id)
+JOIN pkgs p ON (r.pkg_id == p.pkg_id)
 WHERE r.build_id == ? AND r.build_status > 0
 ORDER BY r.breaks DESC
 LIMIT 100
@@ -300,10 +303,10 @@ func (q *Queries) GetPkgsInCategory(ctx context.Context, category string) ([]str
 }
 
 const getResultsInCategory = `-- name: GetResultsInCategory :many
-SELECT r.result_id, r.build_id, r.pkg_id, r.pkg_name, r.build_status, r.failed_deps, r.breaks, r.maintainer_id, p.pkg_id, p.category, p.dir, m.pkg_maintainer
+SELECT r.result_id, r.build_id, r.pkg_id, r.pkg_name, r.build_status, r.failed_deps, r.breaks, r.maintainer_id, p.pkg_id, p.category, p.dir, COALESCE(m.pkg_maintainer, '') AS pkg_maintainer
 FROM results r
 JOIN pkgs p ON (r.pkg_id == p.pkg_id)
-JOIN maintainers m ON (r.maintainer_id == m.maintainer_id)
+LEFT JOIN maintainers m ON (r.maintainer_id == m.maintainer_id)
 WHERE p.category == ? AND r.build_id == ?
 `
 
@@ -412,7 +415,7 @@ const getSingleResult = `-- name: GetSingleResult :one
 SELECT
 	r.result_id,
 	r.pkg_name,
-	m.pkg_maintainer,
+	COALESCE(m.pkg_maintainer, '') AS pkg_maintainer,
 	r.build_status,
 	r.failed_deps,
 	r.breaks,
@@ -425,8 +428,11 @@ SELECT
 	b.compiler,
 	b.build_user,
 	b.report_url
-FROM results r, builds b, maintainers m, pkgs p
-WHERE r.build_id == b.build_id AND r.pkg_id == p.pkg_id AND r.maintainer_id == m.maintainer_id AND r.result_id == ?
+FROM results r
+JOIN builds b ON (r.build_id == b.build_id)
+JOIN pkgs p ON (r.pkg_id == p.pkg_id)
+LEFT JOIN maintainers m ON (r.maintainer_id == m.maintainer_id)
+WHERE r.result_id == ?
 `
 
 type GetSingleResultRow struct {
@@ -474,14 +480,16 @@ const getSingleResultByPkgName = `-- name: GetSingleResultByPkgName :one
 SELECT
 	r.result_id,
 	r.pkg_name,
-	m.pkg_maintainer,
+	COALESCE(m.pkg_maintainer, '') AS pkg_maintainer,
 	r.build_status,
 	r.failed_deps,
 	r.breaks,
 	p.category,
 	p.dir
-FROM results r, pkgs p, maintainers m
-WHERE r.build_id == ? AND r.pkg_id == p.pkg_id AND r.maintainer_id == m.maintainer_id AND r.pkg_name == ?
+FROM results r
+JOIN pkgs p ON (r.pkg_id == p.pkg_id)
+LEFT JOIN maintainers m ON (r.maintainer_id == m.maintainer_id)
+WHERE r.build_id == ? AND r.pkg_name == ?
 `
 
 type GetSingleResultByPkgNameParams struct {
@@ -754,13 +762,14 @@ SELECT
 	r.result_id,
 	(p.category || p.dir) AS pkg_path,
 	r.pkg_name,
-	m.pkg_maintainer,
+	COALESCE(m.pkg_maintainer, '') AS pkg_maintainer,
 	r.build_status,
 	r.failed_deps,
 	r.breaks
 
-FROM results r, maintainers m
-JOIN pkgs p ON (r.pkg_id == p.pkg_id) AND r.maintainer_id == m.maintainer_id
+FROM results r
+LEFT JOIN maintainers m ON (r.maintainer_id == m.maintainer_id)
+JOIN pkgs p ON (r.pkg_id == p.pkg_id)
 WHERE r.build_id = ? AND
 	r.failed_deps LIKE ?
 `

--- a/migrations/1_add_maintainer_to_results.sql
+++ b/migrations/1_add_maintainer_to_results.sql
@@ -4,6 +4,6 @@ CREATE TABLE IF NOT EXISTS maintainers (
 );
 
 ALTER TABLE results
-    ADD COLUMN maintainer_id INTEGER REFERENCES maintainers(maintainer_id);
+    ADD COLUMN maintainer_id INTEGER REFERENCES maintainers(maintainer_id) ON DELETE SET NULL;
 
 CREATE INDEX maintainer_id ON results (maintainer_id);

--- a/queries.sql
+++ b/queries.sql
@@ -41,9 +41,11 @@ ORDER BY pkgpath;
 
 
 -- name: GetAllPkgResults :many
-SELECT r.result_id, r.pkg_name, m.pkg_maintainer, r.build_status, r.breaks, b.build_id, b.platform, b.build_ts, b.branch, b.compiler, b.build_user
-FROM results r, builds b, maintainers m
-WHERE r.build_id == b.build_id AND r.maintainer_id == m.maintainer_id AND r.pkg_id == ?
+SELECT r.result_id, r.pkg_name, COALESCE(m.pkg_maintainer, '') AS pkg_maintainer, r.build_status, r.breaks, b.build_id, b.platform, b.build_ts, b.branch, b.compiler, b.build_user
+FROM results r
+JOIN builds b ON (r.build_id == b.build_id)
+LEFT JOIN maintainers m ON (r.maintainer_id == m.maintainer_id)
+WHERE r.pkg_id == ?
 ORDER BY b.build_ts DESC;
 
 
@@ -58,7 +60,7 @@ WHERE r.build_id = ?;
 SELECT
 	r.result_id,
 	r.pkg_name,
-	m.pkg_maintainer,
+	COALESCE(m.pkg_maintainer, '') AS pkg_maintainer,
 	r.build_status,
 	r.failed_deps,
 	r.breaks,
@@ -71,21 +73,26 @@ SELECT
 	b.compiler,
 	b.build_user,
 	b.report_url
-FROM results r, builds b, maintainers m, pkgs p
-WHERE r.build_id == b.build_id AND r.pkg_id == p.pkg_id AND r.maintainer_id == m.maintainer_id AND r.result_id == ?;
+FROM results r
+JOIN builds b ON (r.build_id == b.build_id)
+JOIN pkgs p ON (r.pkg_id == p.pkg_id)
+LEFT JOIN maintainers m ON (r.maintainer_id == m.maintainer_id)
+WHERE r.result_id == ?;
 
 -- name: GetSingleResultByPkgName :one
 SELECT
 	r.result_id,
 	r.pkg_name,
-	m.pkg_maintainer,
+	COALESCE(m.pkg_maintainer, '') AS pkg_maintainer,
 	r.build_status,
 	r.failed_deps,
 	r.breaks,
 	p.category,
 	p.dir
-FROM results r, pkgs p, maintainers m
-WHERE r.build_id == ? AND r.pkg_id == p.pkg_id AND r.maintainer_id == m.maintainer_id AND r.pkg_name == ?;
+FROM results r
+JOIN pkgs p ON (r.pkg_id == p.pkg_id)
+LEFT JOIN maintainers m ON (r.maintainer_id == m.maintainer_id)
+WHERE r.build_id == ? AND r.pkg_name == ?;
 
 -- name: GetSingleResultIDByPkgName :one
 SELECT result_id
@@ -103,10 +110,10 @@ SELECT pkg_id FROM pkgs
 WHERE category == ? and dir == ?;
 
 -- name: GetResultsInCategory :many
-SELECT r.*, p.*, m.pkg_maintainer
+SELECT r.*, p.*, COALESCE(m.pkg_maintainer, '') AS pkg_maintainer
 FROM results r
 JOIN pkgs p ON (r.pkg_id == p.pkg_id)
-JOIN maintainers m ON (r.maintainer_id == m.maintainer_id)
+LEFT JOIN maintainers m ON (r.maintainer_id == m.maintainer_id)
 WHERE p.category == ? AND r.build_id == ?;
 
 -- name: GetPkgsBreakingMostOthers :many
@@ -114,12 +121,13 @@ SELECT
 	r.result_id,
 	(p.category || p.dir) AS pkg_path,
 	r.pkg_name,
-	m.pkg_maintainer,
+	COALESCE(m.pkg_maintainer, '') AS pkg_maintainer,
 	r.build_status,
 	r.failed_deps,
 	r.breaks
-FROM results r, maintainers m
-JOIN pkgs p ON (r.pkg_id == p.pkg_id) AND r.maintainer_id == m.maintainer_id
+FROM results r
+LEFT JOIN maintainers m ON (r.maintainer_id == m.maintainer_id)
+JOIN pkgs p ON (r.pkg_id == p.pkg_id)
 WHERE r.build_id == ? AND r.build_status > 0
 ORDER BY r.breaks DESC
 LIMIT 100;
@@ -141,13 +149,14 @@ SELECT
 	r.result_id,
 	(p.category || p.dir) AS pkg_path,
 	r.pkg_name,
-	m.pkg_maintainer,
+	COALESCE(m.pkg_maintainer, '') AS pkg_maintainer,
 	r.build_status,
 	r.failed_deps,
 	r.breaks
 
-FROM results r, maintainers m
-JOIN pkgs p ON (r.pkg_id == p.pkg_id) AND r.maintainer_id == m.maintainer_id
+FROM results r
+LEFT JOIN maintainers m ON (r.maintainer_id == m.maintainer_id)
+JOIN pkgs p ON (r.pkg_id == p.pkg_id)
 WHERE r.build_id = ? AND
 	r.failed_deps LIKE ?;
 


### PR DESCRIPTION
Fix #80 by adding LEFT JOIN to queries that are related to maintainers. This should allow for graceful handling of `null` values for older DB entries. 