### PR TITLE
Fetch build stages data while building pkg_info page

### DIFF
--- a/static/pkg_info.css
+++ b/static/pkg_info.css
@@ -1,0 +1,18 @@
+.log-header {
+    margin-bottom: 10px;
+    text-align: right;
+}
+.fullscreen-log {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100% !important;
+    height: 100% !important;
+    z-index: 9999;
+    margin: 0 !important;
+    padding: 20px;
+    background-color: rgba(252, 248, 227, 0.98);
+}
+.fullscreen-frame {
+    height: calc(100vh - 80px) !important;
+}

--- a/static/pkg_info.js
+++ b/static/pkg_info.js
@@ -1,0 +1,57 @@
+$(document).ready(function() {
+    var activeLogName = "";
+    var isFullscreen = false;
+
+    // Disable buttons that have 404 statusCode
+    $("a[name=build-stages]").each(function() {
+      var text = $(this).text();
+      var id = text + ".log";
+      var statusCode = urlData[id].statusCode;
+      if (statusCode == 404) {
+        $(this).addClass("disabled");
+      }
+    });
+
+    $("a[name=build-stages]").click(function(e) {
+      e.preventDefault();
+      var text = $(this).text();
+      var id = text + ".log";
+      var statusCode = urlData[id].statusCode;
+      var url = new String(urlData[id].url);
+      var displayURL = url.length > 90 ? url.substring(0, 40) + " ... " + url.substring(url.length-40, url.length): url;
+      var displayData = urlData[id].data === "" ? "No data available" : urlData[id].data;
+
+      // Add shortcut unicode character to the displayURL
+      displayURL = displayURL + " &#x21D7;"; // Unicode character for link
+
+      $("a[name=build-stages]").removeClass("btn-warning").addClass("btn-default");
+
+      if (activeLogName == text) {
+        $("#logContainer").hide();
+        activeLogName = "";
+        return;
+      } else {
+        $(this).removeClass("btn-default").addClass("btn-warning");
+        activeLogName = text;
+      }
+
+      $("#logFrame").text(urlData[id].error || displayData);
+      $("#logContainer").show();
+      $("#original-logfile").attr("href", urlData[id].url);
+      $("#original-logfile").html(displayURL);
+    });
+    
+    // Toggle fullscreen function
+    $("#toggleFullscreen").click(function() {
+      isFullscreen = !isFullscreen;
+      if (isFullscreen) {
+        $("#logContainer").addClass("fullscreen-log");
+        $("#logFrame").addClass("fullscreen-frame");
+        $(this).html('&#x1F5D9; Collapse'); // Unicode character for collapse
+      } else {
+        $("#logContainer").removeClass("fullscreen-log");
+        $("#logFrame").removeClass("fullscreen-frame");
+        $(this).html('&#x26F6; Fullscreen'); // Unicode character for fullscreen
+      }
+    });
+  });

--- a/static/pkg_info.js
+++ b/static/pkg_info.js
@@ -6,7 +6,7 @@ $(document).ready(function() {
     $("a[name=build-stages]").each(function() {
       var text = $(this).text();
       var id = text + ".log";
-      var statusCode = urlData[id].statusCode;
+      var statusCode = urlData[id].StatusCode;
       if (statusCode == 404) {
         $(this).addClass("disabled");
       }
@@ -16,10 +16,10 @@ $(document).ready(function() {
       e.preventDefault();
       var text = $(this).text();
       var id = text + ".log";
-      var statusCode = urlData[id].statusCode;
-      var url = new String(urlData[id].url);
+      var statusCode = urlData[id].StatusCode;
+      var url = new String(urlData[id].URL);
       var displayURL = url.length > 90 ? url.substring(0, 40) + " ... " + url.substring(url.length-40, url.length): url;
-      var displayData = urlData[id].data === "" ? "No data available" : urlData[id].data;
+      var displayData = urlData[id].Data === "" ? "No data available" : urlData[id].Data;
 
       // Add shortcut unicode character to the displayURL
       displayURL = displayURL + " &#x21D7;"; // Unicode character for link
@@ -35,9 +35,9 @@ $(document).ready(function() {
         activeLogName = text;
       }
 
-      $("#logFrame").text(urlData[id].error || displayData);
+      $("#logFrame").text(urlData[id].Error || displayData);
       $("#logContainer").show();
-      $("#original-logfile").attr("href", urlData[id].url);
+      $("#original-logfile").attr("href", urlData[id].URL);
       $("#original-logfile").html(displayURL);
     });
     

--- a/templates/pkg_info.html
+++ b/templates/pkg_info.html
@@ -6,7 +6,7 @@
           <a href="{{.BasePath}}build/{{.Res.BuildID}}/{{.Res.Category}}" class="btn btn-primary">{{.Res.Category}}</a>
           <a href="{{.BasePath}}{{.Res.Category}}{{.Res.Dir}}" class="btn btn-default">Other builds of this package</a>
           {{if ne .Res.Category "joyent/"}}
-          <a href="//pkgsrc.se/{{.Res.Category}}{{.Res.Dir}}" class="btn btn-default">pkgsrc.se</a>
+            <a href="//pkgsrc.se/{{.Res.Category}}{{.Res.Dir}}" class="btn btn-default">pkgsrc.se</a>
           {{end}}
         </div>
       </dd>
@@ -20,105 +20,58 @@
       <dd>{{.Res.PkgMaintainer}}</dd>
       <dt>Build Status</dt>
       {{if eq .Res.BuildStatus 0}}
-      <dd><span class="label label-success">ok</span></dd>
+        <dd><span class="label label-success">ok</span></dd>
       {{else if eq .Res.BuildStatus 1}}
-      <dd><span class="label label-info">prefailed</span></dd>
+        <dd><span class="label label-info">prefailed</span></dd>
       {{else if eq .Res.BuildStatus 2}}
-      <dd><span class="label label-danger">failed</span></dd>
+        <dd><span class="label label-danger">failed</span></dd>
       {{else if eq .Res.BuildStatus 3}}
-      <dd><span class="label label-warning">indirect-failed</span></dd>
+        <dd><span class="label label-warning">indirect-failed</span></dd>
       {{else if eq .Res.BuildStatus 4}}
-      <dd><span class="label label-info">indirect-prefailed</span></dd>
+        <dd><span class="label label-info">indirect-prefailed</span></dd>
       {{end}}
       {{if eq .Res.BuildStatus 2}}
-      <dt>Build Logs</dt>
-      <script>
-        $(document).ready(function() {
-          var activeLogName = "";
-          var isFullscreen = false;
-
-          $("a[name=build-stages]").click(function(e) {
-            e.preventDefault();
-            var text = $(this).text();
-
-            $("a[name=build-stages]").removeClass("btn-warning").addClass("btn-default");
-
-            if (activeLogName == text) {
-              $("#logContainer").hide();
-              activeLogName = "";
-              return;
-            } else {
-              $(this).removeClass("btn-default").addClass("btn-warning");
-              activeLogName = text;
-            }
-
-            var url = "{{.Res.BaseURL}}{{.Res.PkgName}}/" + text.toLowerCase() + ".log";
-            
-            // Replace the load method with iframe approach
-            $("#logFrame").attr("src", url);
-            $("#logContainer").show();
-          });
-          
-          // Toggle fullscreen function
-          $("#toggleFullscreen").click(function() {
-            isFullscreen = !isFullscreen;
-            if (isFullscreen) {
-              $("#logContainer").addClass("fullscreen-log");
-              $("#logFrame").addClass("fullscreen-iframe");
-              $(this).html('&#x1F5D9; Collapse'); // Unicode character for collapse
-            } else {
-              $("#logContainer").removeClass("fullscreen-log");
-              $("#logFrame").removeClass("fullscreen-iframe");
-              $(this).html('&#x26F6; Fullscreen'); // Unicode character for fullscreen
-            }
-          });
-	  $("#go").click(function() {
-	    window.open($("#logFrame").attr("src"), "_blank");
-	  });
-        });
-      </script>
-      <dd>
-        <div class="btn-group btn-group-sm">
-          <a href="{{.Res.BaseURL}}{{.Res.PkgName}}/work.log" name="build-stages" class="btn btn-default">work</a>
-          <a href="{{.Res.BaseURL}}{{.Res.PkgName}}/pre-clean.log" name="build-stages" class="btn btn-default">pre-clean</a>
-          <a href="{{.Res.BaseURL}}{{.Res.PkgName}}/checksum.log" name="build-stages" class="btn btn-default">checksum</a>
-          <a href="{{.Res.BaseURL}}{{.Res.PkgName}}/depends.log" name="build-stages" class="btn btn-default">depends</a>
-          <a href="{{.Res.BaseURL}}{{.Res.PkgName}}/configure.log" name="build-stages" class="btn btn-default">configure</a>
-          <a href="{{.Res.BaseURL}}{{.Res.PkgName}}/build.log" name="build-stages" class="btn btn-default">build</a>
-          <a href="{{.Res.BaseURL}}{{.Res.PkgName}}/install.log" name="build-stages" class="btn btn-default">install</a>
+        <dt>Build Logs</dt>
+        <script>
+          // Create JavaScript object with URLData
+          var urlData = {
+            {{range .URLData}}
+            {{.ID}}:
+            {
+              id: {{.ID}},
+              url: {{.URL}},
+              statusCode: {{.StatusCode}},
+              {{if .Error}}
+              error: {{.Error}},
+              {{else}}
+              data: {{.Data}},
+              {{end}}
+            },
+            {{end}}
+          };
+        </script>
+        <dd>
+          <div class="btn-group btn-group-sm">
+            <a href="{{.Res.BaseURL}}{{.Res.PkgName}}/work.log" name="build-stages" class="btn btn-default">work</a>
+            <a href="{{.Res.BaseURL}}{{.Res.PkgName}}/pre-clean.log" name="build-stages" class="btn btn-default">pre-clean</a>
+            <a href="{{.Res.BaseURL}}{{.Res.PkgName}}/checksum.log" name="build-stages" class="btn btn-default">checksum</a>
+            <a href="{{.Res.BaseURL}}{{.Res.PkgName}}/depends.log" name="build-stages" class="btn btn-default">depends</a>
+            <a href="{{.Res.BaseURL}}{{.Res.PkgName}}/configure.log" name="build-stages" class="btn btn-default">configure</a>
+            <a href="{{.Res.BaseURL}}{{.Res.PkgName}}/build.log" name="build-stages" class="btn btn-default">build</a>
+            <a href="{{.Res.BaseURL}}{{.Res.PkgName}}/install.log" name="build-stages" class="btn btn-default">install</a>
+          </div>
+        </dd>
+        <div id="logContainer" class="alert alert-warning" style="display:none;width: 80%;margin-left: 180px;">
+          <div class="log-header">
+            <button id="toggleFullscreen" class="btn btn-sm btn-default pull-right">
+              &#x26F6; Fullscreen
+            </button>
+            <a id="original-logfile" href="" class="pull-left" target="_blank"></a>
+          </div>
+          <pre id="logFrame" style="width:100%; height:400px; border:none;"></pre>
         </div>
-      </dd>
-      <div id="logContainer" class="alert alert-warning" style="display:none;width: 80%;margin-left: 180px;">
-        <div class="log-header">
-          <button id="toggleFullscreen" class="btn btn-sm btn-default pull-right">
-             &#x26F6; Fullscreen
-          </button>
-          <button id="go" class="btn btn-sm pull-right">
-             Go
-          </button>
-        </div>
-        <iframe id="logFrame" style="width:100%; height:400px; border:none;"></iframe>
-      </div>
-      <style>
-        .log-header {
-          margin-bottom: 10px;
-          text-align: right;
-        }
-        .fullscreen-log {
-          position: fixed;
-          top: 0;
-          left: 0;
-          width: 100% !important;
-          height: 100% !important;
-          z-index: 9999;
-          margin: 0 !important;
-          padding: 20px;
-          background-color: rgba(252, 248, 227, 0.98);
-        }
-        .fullscreen-iframe {
-          height: calc(100vh - 80px) !important;
-        }
-      </style>
+        <link href="{{.BasePath}}static/pkg_info.css" rel="stylesheet">
+        <script src="{{.BasePath}}static/pkg_info.js"></script>
       {{end}}
       <dt>Platform</dt>
       <dd>{{.Res.Platform}}</dd>

--- a/templates/pkg_info.html
+++ b/templates/pkg_info.html
@@ -33,22 +33,8 @@
       {{if eq .Res.BuildStatus 2}}
         <dt>Build Logs</dt>
         <script>
-          // Create JavaScript object with URLData
-          var urlData = {
-            {{range .URLData}}
-            {{.ID}}:
-            {
-              id: {{.ID}},
-              url: {{.URL}},
-              statusCode: {{.StatusCode}},
-              {{if .Error}}
-              error: {{.Error}},
-              {{else}}
-              data: {{.Data}},
-              {{end}}
-            },
-            {{end}}
-          };
+          // URLData is used by pkg_info.js to load the logs
+          var urlData = {{.URLDataJSON}};
         </script>
         <dd>
           <div class="btn-group btn-group-sm">

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -163,7 +163,7 @@ func PkgInfo(w io.Writer, res ddao.GetSingleResultRow) {
 	wg.Add(len(stages))
 
 	// Create a context with a 10-second timeout
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
 	// Fetch URLs in parallel
@@ -294,7 +294,10 @@ func SentinelsInit(w io.Writer, selector string, apiName string, number int64) {
 	})
 }
 
-// URLRequestResult represents the result of a URL request
+// URLRequestResult represents the result of a URL request where the
+// ID is the stage name, URL is the request URL, StatusCode is the HTTP
+// status code, Data is the response body, and Error is any error that
+// occurred during the request (if any).
 type URLRequestResult struct {
 	ID         string
 	URL        string

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -23,6 +23,7 @@ package templates
 import (
 	"context"
 	"embed"
+	"encoding/json"
 	"fmt"
 	"html/template"
 	"io"
@@ -142,6 +143,16 @@ func BulkBuildInfo(w io.Writer, b *ddao.Build) {
 	t.ExecuteTemplate(w, "bulk_build_info.html", b)
 }
 
+// marshalToJSON marshals the given data to a JSON string that can be used in JavaScript.
+// Returns a template.JS value to prevent HTML escaping of the JSON.
+func marshalToJSON(data interface{}) (template.JS, error) {
+	jsonBytes, err := json.Marshal(data)
+	if err != nil {
+		return "", err
+	}
+	return template.JS(jsonBytes), nil
+}
+
 func PkgInfo(w io.Writer, res ddao.GetSingleResultRow) {
 	// Define what to fetch - these represent the stages of the build process
 	// and are used to fetch the corresponding log files.
@@ -215,18 +226,32 @@ func PkgInfo(w io.Writer, res ddao.GetSingleResultRow) {
 	// Wait for all requests to complete
 	wg.Wait()
 
+	// Create a map of URL results for JSON marshalling
+	urlDataMap := make(map[string]URLRequestResult)
+	for _, result := range results {
+		urlDataMap[result.ID] = result
+	}
+
+	// Marshal URL data to JSON
+	jsonData, err := marshalToJSON(urlDataMap)
+	if err != nil {
+		log.Errorf(ctx, "templates.PkgInfo: Error marshalling URL data: %v", err)
+	}
+
 	// Create the structure to pass to the template
 	s := struct {
-		Res     *ddao.GetSingleResultRow
-		URLData []URLRequestResult
+		Res         *ddao.GetSingleResultRow
+		URLData     []URLRequestResult
+		URLDataJSON template.JS
 		bp
 	}{
-		Res:     &res,
-		URLData: results,
+		Res:         &res,
+		URLData:     results,
+		URLDataJSON: jsonData,
 	}
 
 	// Execute the template
-	err := t.ExecuteTemplate(w, "pkg_info.html", s)
+	err = t.ExecuteTemplate(w, "pkg_info.html", s)
 	if err != nil {
 		log.Errorf(ctx, "templates.PkgInfo: %v", err)
 	}

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -26,6 +26,9 @@ import (
 	"fmt"
 	"html/template"
 	"io"
+	"net/http"
+	"sync"
+	"time"
 
 	"github.com/bsiegert/BulkTracker/ddao"
 	"github.com/bsiegert/BulkTracker/log"
@@ -140,15 +143,92 @@ func BulkBuildInfo(w io.Writer, b *ddao.Build) {
 }
 
 func PkgInfo(w io.Writer, res ddao.GetSingleResultRow) {
+	// Define what to fetch - these represent the stages of the build process
+	// and are used to fetch the corresponding log files.
+	stages := []string{
+		"work.log",
+		"pre-clean.log",
+		"checksum.log",
+		"depends.log",
+		"configure.log",
+		"build.log",
+		"install.log",
+	}
+
+	// Create results slice
+	results := make([]URLRequestResult, len(stages))
+
+	// Create a WaitGroup to wait for all goroutines
+	var wg sync.WaitGroup
+	wg.Add(len(stages))
+
+	// Create a context with a 10-second timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Fetch URLs in parallel
+	for i, s := range stages {
+		// Construct the URL for the current stage
+		url := fmt.Sprintf("%s%s/%s", res.BaseURL(), res.PkgName, s)
+
+		// Start a goroutine for each URL to fetch stage data
+		go func(index int, stage string, reqURL string) {
+			defer wg.Done()
+
+			// Initialize result with ID and URL
+			results[index] = URLRequestResult{
+				ID:  stage,
+				URL: reqURL,
+			}
+
+			// Create a new request with the context
+			req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil)
+			if err != nil {
+				results[index].StatusCode = http.StatusInternalServerError
+				results[index].Error = err.Error()
+				return
+			}
+
+			// Make the request
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				results[index].StatusCode = http.StatusInternalServerError
+				results[index].Error = err.Error()
+				return
+			}
+			defer resp.Body.Close()
+
+			// Read the response body
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				results[index].StatusCode = resp.StatusCode
+				results[index].Error = err.Error()
+				return
+			}
+
+			// Store the result
+			results[index].StatusCode = resp.StatusCode
+			results[index].Data = string(body)
+		}(i, s, url) // i is index, s is stage, url is the constructed URL
+	}
+
+	// Wait for all requests to complete
+	wg.Wait()
+
+	// Create the structure to pass to the template
 	s := struct {
-		Res *ddao.GetSingleResultRow
+		Res     *ddao.GetSingleResultRow
+		URLData []URLRequestResult
 		bp
 	}{
-		Res: &res,
+		Res:     &res,
+		URLData: results,
 	}
+
+	// Execute the template
 	err := t.ExecuteTemplate(w, "pkg_info.html", s)
 	if err != nil {
-		log.Errorf(context.TODO(), "templates.PkgInfo: %v", err)
+		log.Errorf(ctx, "templates.PkgInfo: %v", err)
 	}
 }
 
@@ -212,4 +292,13 @@ func SentinelsInit(w io.Writer, selector string, apiName string, number int64) {
 		APIName:  apiName,
 		Number:   number,
 	})
+}
+
+// URLRequestResult represents the result of a URL request
+type URLRequestResult struct {
+	ID         string
+	URL        string
+	StatusCode int
+	Data       string
+	Error      string
 }

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -162,7 +162,7 @@ func PkgInfo(w io.Writer, res ddao.GetSingleResultRow) {
 	var wg sync.WaitGroup
 	wg.Add(len(stages))
 
-	// Create a context with a 10-second timeout
+	// Create a context with a 2-second timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 


### PR DESCRIPTION
Added simple go routine that fetches in parallel all build stages data while pkg_info page is being built. This solves #88 and #75.

Buttons that are pointing to log files (buiild stages) that don't exist (404) are now disabled. :tada:  HTTP status codes are also captured and available for future improvements if we would like to style output further and highlight errors or similar. :bulb: 

For security and stability reasons `iframe` is replaced with `pre` HTML element. Additionally added link to original log location instead of Go button to make it more visible to the users where the log file is and what are they navigating to. In case this URL is too long, middle of URL is shortened and replaced with ` ... `.

Additionally, CSS and JS code is extracted in external CSS and JS files :tada: 

@bsiegert , please review - all feedback welcome!