### PR TITLE
Fix #66 Add tag results at the end

### DIFF
--- a/static/select-pkgresult.js
+++ b/static/select-pkgresult.js
@@ -11,6 +11,10 @@ $(document).ready(function() {
     ajax: {
       url: bt.basePath+'json/autocomplete/',
       dataType: 'json'
+    },
+    insertTag: function(data, tag) {
+      // Insert the user-typed tag at the end instead of the beginning
+      data.push(tag);
     }
   });
 });


### PR DESCRIPTION
Hey @bsiegert , 

this took me quite some time to find a right approach and it is working but to be honest I don't like it! When the list of results is long,  it pushes what user types to the end of the list and it is not visible at all until you scroll down. I like it much more how it was on the top so I suggest we don't do this and just discard this PR and close related issue.

Let me know what do you think!